### PR TITLE
Bugfix - Error handling when req json is empty

### DIFF
--- a/ui/onlinescreen.py
+++ b/ui/onlinescreen.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 import threading
 from functools import partial
 from kivy.uix.screenmanager import Screen
@@ -55,9 +56,19 @@ class OnlineScreen(Screen):
             req.raise_for_status()
         except requests.exceptions.RequestException:
             err.append('Unable to reach the login server.')
-        resp = req.json()
-        if resp['status'] != 'OK':
+        
+        resp = None
+
+        try:
+            resp = req.json()
+        except JSONDecodeError:
+            err.append('Could not retrieve data from server.')
+            return err
+
+        if resp != None and resp['status'] != 'OK':
             err.append(resp['msg'])
+        elif resp == None:
+            return err
         else:
             self.app.player_name = name #assign name to be used everywhere
         return err


### PR DESCRIPTION
There was no try catch yet to see if the request json was empty or not. This caused the client to crash, changed it to give an error back instead.